### PR TITLE
Increase ID capacities for map blocks/biomes

### DIFF
--- a/core/src/main/java/net/pl3x/map/core/registry/BiomeRegistry.java
+++ b/core/src/main/java/net/pl3x/map/core/registry/BiomeRegistry.java
@@ -42,7 +42,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public class BiomeRegistry extends Registry<Biome> {
     private static final Gson GSON = new GsonBuilder().create();
-    public static final int MAX_INDEX = 511;
+    public static final int MAX_INDEX = 16383;
 
     private final Map<String, Integer> indexMap;
     private int lastIndex = 0;

--- a/core/src/main/java/net/pl3x/map/core/registry/BlockRegistry.java
+++ b/core/src/main/java/net/pl3x/map/core/registry/BlockRegistry.java
@@ -42,7 +42,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public class BlockRegistry extends Registry<Block> {
     private static final Gson GSON = new GsonBuilder().create();
-    public static final int MAX_INDEX = 2047;
+    public static final int MAX_INDEX = 65535;
 
     private final Map<String, Integer> indexMap;
     private int lastIndex = 0;

--- a/core/src/main/java/net/pl3x/map/core/renderer/BlockInfoRenderer.java
+++ b/core/src/main/java/net/pl3x/map/core/renderer/BlockInfoRenderer.java
@@ -56,7 +56,7 @@ public class BlockInfoRenderer extends Renderer {
 
     @Override
     public void allocateData(Point region) {
-        this.byteBuffer = ByteBuffer.allocate(512 * 512 * 4 + 12);
+        this.byteBuffer = ByteBuffer.allocate(512 * 512 * 8 + 12);
         Path path = getWorld().getTilesDirectory()
                 .resolve(String.format(TileImage.DIR_PATH, 0, getKey()))
                 .resolve(String.format(TileImage.FILE_PATH, region.x(), region.z(), "pl3xmap.gz"));
@@ -122,9 +122,9 @@ public class BlockInfoRenderer extends Renderer {
                     for (int x = 0; x < 512; x += step) {
                         for (int z = 0; z < 512; z += step) {
                             int index = z * 512 + x;
-                            int packed = ByteUtil.getInt(this.byteBuffer, 12 + index * 4);
+                            long packed = ByteUtil.getLong(this.byteBuffer, 12 + index * 8);
                             int newIndex = (baseZ + (z / step)) * 512 + (baseX + (x / step));
-                            buffer.put(12 + newIndex * 4, ByteUtil.toBytes(packed));
+                            buffer.put(12 + newIndex * 8, ByteUtil.toBytes(packed));
                         }
                     }
 
@@ -167,12 +167,12 @@ public class BlockInfoRenderer extends Renderer {
         int blockIndex = block.getIndex() == -1 ? Blocks.AIR.getIndex() : block.getIndex();
         int biomeIndex = biome.index() == -1 ? Biome.DEFAULT.index() : biome.index();
 
-        // 11111111111111111111111111111111 - 32 bits - (4294967295)
-        // 11111111111                      - 11 bits - block (2047)
-        //            111111111             -  9 bits - biome (511)
-        //                     111111111111 - 12 bits - yPos  (4095)
-        int packed = ((blockIndex & 2047) << 21) | ((biomeIndex & 511) << 12) | (y & 4095);
+        // packed into 64 bits
+        // 1111111111111111                      - 16 bits - block (65535)
+        //                 1111111111111111      - 16 bits - biome (65535)
+        //                                 1111111111111111 - 16 bits - yPos (65535)
+        long packed = ((long) (blockIndex & 0xFFFF) << 32) | ((long) (biomeIndex & 0xFFFF) << 16) | (y & 0xFFFF);
         int index = (blockZ & 511) * 512 + (blockX & 511);
-        this.byteBuffer.put(12 + index * 4, ByteUtil.toBytes(packed));
+        this.byteBuffer.put(12 + index * 8, ByteUtil.toBytes(packed));
     }
 }

--- a/core/src/main/java/net/pl3x/map/core/util/ByteUtil.java
+++ b/core/src/main/java/net/pl3x/map/core/util/ByteUtil.java
@@ -39,10 +39,26 @@ public class ByteUtil {
         return bytes;
     }
 
+    public static byte[] toBytes(long packed) {
+        byte[] bytes = new byte[Long.BYTES];
+        for (int i = 0; i < Long.BYTES; i++) {
+            bytes[i] = (byte) (packed >>> (Byte.SIZE * (Long.BYTES - 1 - i)));
+        }
+        return bytes;
+    }
+
     public static int getInt(ByteBuffer buffer, int index) {
         int value = 0;
         for (int i = 0; i < Integer.BYTES; i++) {
             value |= (buffer.get(index + i) & 0xFF) << (Byte.SIZE * (Integer.BYTES - 1 - i));
+        }
+        return value;
+    }
+
+    public static long getLong(ByteBuffer buffer, int index) {
+        long value = 0;
+        for (int i = 0; i < Long.BYTES; i++) {
+            value |= ((long) buffer.get(index + i) & 0xFFL) << (Byte.SIZE * (Long.BYTES - 1 - i));
         }
         return value;
     }

--- a/webmap/src/palette/Block.ts
+++ b/webmap/src/palette/Block.ts
@@ -4,14 +4,14 @@ export class Block {
     private readonly _yPos: number;
     private readonly _minY: number;
 
-    constructor(packed: number, minY: number) {
-        // 11111111111111111111111111111111 - 32 bits - (4294967295)
-        // 11111111111                      - 11 bits - block (2047)
-        //            111111111             -  9 bits - biome (511)
-        //                     111111111111 - 12 bits - yPos  (4095)
-        this._block = packed >>> 21;
-        this._biome = (packed & 0b00000000000_111111111_000000000000) >>> 12;
-        this._yPos = packed & 0b00000000000_000000000_111111111111;
+    constructor(packed: bigint, minY: number) {
+        // packed into 64 bits
+        // 1111111111111111                      - 16 bits - block (65535)
+        //                 1111111111111111      - 16 bits - biome (65535)
+        //                                 1111111111111111 - 16 bits - yPos (65535)
+        this._block = Number((packed >> 32n) & 0xFFFFn);
+        this._biome = Number((packed >> 16n) & 0xFFFFn);
+        this._yPos = Number(packed & 0xFFFFn);
         this._minY = minY;
     }
 

--- a/webmap/src/palette/BlockInfo.ts
+++ b/webmap/src/palette/BlockInfo.ts
@@ -2,7 +2,7 @@ import {Block} from "./Block";
 
 export class BlockInfo {
     public readonly BYTE_SIZE: number = 8;
-    public readonly INTEGER_BYTES: number = 4;
+    public readonly LONG_BYTES: number = 8;
 
     private readonly _data: Uint8Array;
 
@@ -15,13 +15,21 @@ export class BlockInfo {
     }
 
     getBlock(index: number): Block {
-        return new Block(this.getInt(12 + index * 4), this.minY);
+        return new Block(this.getLong(12 + index * 8), this.minY);
     }
 
     private getInt(position: number): number {
         let val: number = 0;
-        for (let i: number = 0; i < this.INTEGER_BYTES; i++) {
-            val |= (this._data[position + i] & 0xFF) << (this.BYTE_SIZE * ((this.INTEGER_BYTES - 1) - i));
+        for (let i: number = 0; i < 4; i++) {
+            val |= (this._data[position + i] & 0xFF) << (this.BYTE_SIZE * ((4 - 1) - i));
+        }
+        return val;
+    }
+
+    private getLong(position: number): bigint {
+        let val = 0n;
+        for (let i = 0; i < this.LONG_BYTES; i++) {
+            val |= BigInt(this._data[position + i] & 0xFF) << BigInt(this.BYTE_SIZE * ((this.LONG_BYTES - 1) - i));
         }
         return val;
     }

--- a/webmap/tsconfig.json
+++ b/webmap/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es6",                                     /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2020",                                   /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */


### PR DESCRIPTION
## Summary
- enlarge `MAX_INDEX` in `BlockRegistry` and `BiomeRegistry`
- expand blockinfo format to 64 bits
- update byte utilities for 64‑bit values
- update renderer to read/write larger packed values
- adjust TypeScript decoding of blockinfo tiles
- update TypeScript compilation target to ES2020

## Testing
- `./gradlew jar -x test` *(fails: Failed download from piston-meta.mojang.com)*
- `npm run build` in `webmap` *(passes with asset warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6874ee802620832dbc3a7e94354af9c3