### PR TITLE
Add MTR overlay layer

### DIFF
--- a/webmap/src/Pl3xMap.ts
+++ b/webmap/src/Pl3xMap.ts
@@ -2,11 +2,13 @@ import {Settings} from "./settings/Settings";
 import {ControlManager} from "./control/ControlManager";
 import {PlayerManager} from "./player/PlayerManager";
 import {WorldManager} from "./world/WorldManager";
+import {World} from "./world/World";
 import {getJSON} from "./util/Util";
 import SidebarControl from "./control/SidebarControl";
 import Pl3xMapLeafletMap from "./map/Pl3xMapLeafletMap";
 import "./scss/styles.scss";
 import {Player} from "./player/Player";
+import MTRLayer from "./mtr/MTRLayer";
 
 window.onload = function (): void {
     window.pl3xmap = new Pl3xMap();
@@ -31,6 +33,7 @@ export class Pl3xMap {
 
     private _timestamp: number = (new Date()).getTime();
     private _timer: NodeJS.Timeout | undefined;
+    private _mtrLayer?: MTRLayer;
 
     constructor() {
         Pl3xMap._instance = this;
@@ -62,6 +65,14 @@ export class Pl3xMap {
             const promise: Promise<void> = this.worldManager.init(this._settings);
             this._eventSource = this.initSSE();
             this.update();
+
+            window.addEventListener('worldselected', (e: CustomEvent): void => {
+                this._mtrLayer?.unload();
+                const world = e.detail as World;
+                this._mtrLayer = new MTRLayer(world, 'mtr/');
+                this._mtrLayer.addTo(this.map);
+            });
+
             return promise;
         });
     }

--- a/webmap/src/mtr/MTRLayer.ts
+++ b/webmap/src/mtr/MTRLayer.ts
@@ -1,0 +1,84 @@
+import * as L from "leaflet";
+import {fireCustomEvent, toCenteredLatLng} from "../util/Util";
+import {World} from "../world/World";
+import {Point} from "../util/Point";
+
+export default class MTRLayer extends L.LayerGroup {
+    readonly key = "mtr";
+    readonly label = "MTR";
+    readonly priority = 0;
+    readonly showControls = true;
+    readonly defaultHidden = false;
+
+    private _world: World;
+    private _url: string;
+
+    constructor(world: World, baseUrl: string) {
+        super([], { attribution: undefined });
+        this._world = world;
+        this._url = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
+        this.load();
+        fireCustomEvent("overlayadded", this as any);
+    }
+
+    private dimension(): number {
+        switch (this._world.type) {
+            case "nether":
+                return 1;
+            case "the_end":
+                return 2;
+            default:
+                return 0;
+        }
+    }
+
+    private async load(): Promise<void> {
+        try {
+            const response = await fetch(this._url + "data", { cache: "no-cache" });
+            const json = await response.json();
+            this.parse(json[this.dimension()] ?? {});
+        } catch (e) {
+            console.error("Failed to load MTR data", e);
+        }
+    }
+
+    private parse(data: any): void {
+        this.clearLayers();
+        const positions = data.positions ?? {};
+        const stations = data.stations ?? {};
+        const routes = data.routes ?? [];
+
+        Object.values(stations).forEach((s: any) => {
+            const color = "#" + (s.color >>> 0).toString(16).padStart(6, "0");
+            const marker = L.circleMarker(toCenteredLatLng(new Point(s.x, s.z)), {
+                radius: 3,
+                color,
+                weight: 1,
+                fillOpacity: 1
+            });
+            if (s.name) {
+                marker.bindTooltip(s.name);
+            }
+            marker.addTo(this);
+        });
+
+        routes.forEach((r: any) => {
+            const pts: L.LatLng[] = [];
+            r.stations.forEach((sid: string) => {
+                const pos = positions[sid];
+                if (pos) {
+                    pts.push(toCenteredLatLng(new Point(pos.x, pos.y)));
+                }
+            });
+            if (pts.length >= 2) {
+                const color = "#" + (r.color >>> 0).toString(16).padStart(6, "0");
+                L.polyline(pts, { color, weight: 2 }).addTo(this);
+            }
+        });
+    }
+
+    unload(): void {
+        this.clearLayers();
+        fireCustomEvent("overlayremoved", this as any);
+    }
+}


### PR DESCRIPTION
## Summary
- add `MTRLayer` for displaying Minecraft Transit Railway data
- load overlay whenever a world is selected

## Testing
- `npm install`
- `npm run build`
- `./gradlew build` *(failed: lock waiting)*

------
https://chatgpt.com/codex/tasks/task_e_6878ee68fdf0832db6489fb21f318139