### PR TITLE
Add MTR overlay layer

### DIFF
--- a/core/src/main/java/net/pl3x/map/core/Pl3xMap.java
+++ b/core/src/main/java/net/pl3x/map/core/Pl3xMap.java
@@ -43,6 +43,7 @@ import net.pl3x.map.core.configuration.Lang;
 import net.pl3x.map.core.configuration.PlayersLayerConfig;
 import net.pl3x.map.core.configuration.SpawnLayerConfig;
 import net.pl3x.map.core.configuration.WorldBorderLayerConfig;
+import net.pl3x.map.core.configuration.MTRLayerConfig;
 import net.pl3x.map.core.event.EventRegistry;
 import net.pl3x.map.core.event.server.Pl3xMapDisabledEvent;
 import net.pl3x.map.core.event.server.Pl3xMapEnabledEvent;
@@ -198,6 +199,7 @@ public abstract class Pl3xMap {
         PlayersLayerConfig.reload();
         SpawnLayerConfig.reload();
         WorldBorderLayerConfig.reload();
+        MTRLayerConfig.reload();
 
         // initialize block registry
         getBlockRegistry().init();

--- a/core/src/main/java/net/pl3x/map/core/configuration/MTRLayerConfig.java
+++ b/core/src/main/java/net/pl3x/map/core/configuration/MTRLayerConfig.java
@@ -1,0 +1,68 @@
+package net.pl3x.map.core.configuration;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import net.pl3x.map.core.Pl3xMap;
+import net.pl3x.map.core.util.Colors;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("CanBeFinal")
+public final class MTRLayerConfig extends AbstractConfig {
+    @Key("settings.enabled")
+    @Comment("""
+            Show Minecraft Transit Railway overlay on the map.""")
+    public static boolean ENABLED = true;
+
+    @Key("settings.layer.show-controls")
+    @Comment("""
+            Whether this layer control shows up in the layers list or not.""")
+    public static boolean SHOW_CONTROLS = true;
+    @Key("settings.layer.default-hidden")
+    @Comment("""
+            Whether the layer should be hidden (toggled off) by default.""")
+    public static boolean DEFAULT_HIDDEN = false;
+    @Key("settings.layer.priority")
+    @Comment("""
+            Priority order this layer shows up in the layers list.
+            (lower values = higher in the list)""")
+    public static int PRIORITY = 40;
+    @Key("settings.layer.z-index")
+    @Comment("""
+            Z-Index order this layer shows up in the map.
+            (higher values are drawn on top of lower values)""")
+    public static int Z_INDEX = 800;
+
+    @Key("settings.icons.station")
+    @Comment("""
+            Icon to use for stations.""")
+    public static String STATION_ICON = "marker-icon";
+    @Key("settings.icons.depot")
+    @Comment("""
+            Icon to use for depots.""")
+    public static String DEPOT_ICON = "marker-icon";
+
+    @Key("settings.routes")
+    @Comment("""
+            Override colors for routes by name.""")
+    public static Map<@NotNull String, @NotNull Integer> ROUTE_COLORS = new LinkedHashMap<>();
+
+    private static final MTRLayerConfig CONFIG = new MTRLayerConfig();
+
+    public static void reload() {
+        CONFIG.reload(Pl3xMap.api().getMainDir().resolve("layers/mtr.yml"), MTRLayerConfig.class);
+    }
+
+    @Override
+    protected @NotNull Object addToMap(@NotNull String rawValue) {
+        return Colors.fromHex(rawValue);
+    }
+
+    @Override
+    protected void set(@NotNull String path, @NotNull Object value) {
+        if (value instanceof Map<?, ?> map) {
+            map.forEach((key, val) -> getConfig().set(path + "." + key, Colors.toHex((int) val)));
+        } else {
+            getConfig().set(path, value);
+        }
+    }
+}

--- a/core/src/main/java/net/pl3x/map/core/markers/layer/MTRLayer.java
+++ b/core/src/main/java/net/pl3x/map/core/markers/layer/MTRLayer.java
@@ -1,0 +1,208 @@
+package net.pl3x.map.core.markers.layer;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.imageio.ImageIO;
+import net.pl3x.map.core.Pl3xMap;
+import net.pl3x.map.core.configuration.MTRLayerConfig;
+import net.pl3x.map.core.image.IconImage;
+import net.pl3x.map.core.log.Logger;
+import net.pl3x.map.core.markers.Point;
+import net.pl3x.map.core.markers.marker.Icon;
+import net.pl3x.map.core.markers.marker.Marker;
+import net.pl3x.map.core.markers.marker.Polyline;
+import net.pl3x.map.core.markers.option.Options;
+import net.pl3x.map.core.markers.option.Stroke;
+import net.pl3x.map.core.markers.option.Tooltip;
+import net.pl3x.map.core.util.Colors;
+import net.pl3x.map.core.util.FileUtil;
+import net.pl3x.map.core.world.World;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Display Minecraft Transit Railway routes and stations.
+ */
+public class MTRLayer extends WorldLayer {
+    public static final String KEY = "pl3xmap_mtr";
+
+    public static boolean hasData(@NotNull World world) {
+        Path file = FileUtil.getWebDir().resolve("mtr/data");
+        if (Files.exists(file)) {
+            return true;
+        }
+        Path worldDir = world.getRegionDirectory().getParent();
+        file = worldDir.resolve("mtr/data");
+        return Files.exists(file);
+    }
+
+    private final String stationIcon;
+    private final String depotIcon;
+
+    private final Map<String, JsonObject> positions = new HashMap<>();
+    private final Map<String, JsonObject> stations = new HashMap<>();
+    private final Map<String, JsonObject> depots = new HashMap<>();
+    private final List<JsonObject> routes = new ArrayList<>();
+
+    public MTRLayer(@NotNull World world) {
+        super(KEY, world, () -> "MTR");
+
+        this.stationIcon = MTRLayerConfig.STATION_ICON;
+        this.depotIcon = MTRLayerConfig.DEPOT_ICON;
+
+        setShowControls(MTRLayerConfig.SHOW_CONTROLS);
+        setDefaultHidden(MTRLayerConfig.DEFAULT_HIDDEN);
+        setPriority(MTRLayerConfig.PRIORITY);
+        setZIndex(MTRLayerConfig.Z_INDEX);
+
+        registerIcon(this.stationIcon);
+        registerIcon(this.depotIcon);
+
+        loadData();
+    }
+
+    private void registerIcon(@NotNull String name) {
+        try {
+            Path icon = FileUtil.getWebDir().resolve("images/icon/" + name + ".png");
+            IconImage image = new IconImage(name, ImageIO.read(icon.toFile()), "png");
+            Pl3xMap.api().getIconRegistry().register(image);
+        } catch (IOException e) {
+            Logger.warn("Could not register icon " + name, e);
+        }
+    }
+
+    private int dimension() {
+        return switch (getWorld().getType()) {
+            case NETHER -> 1;
+            case THE_END -> 2;
+            default -> 0;
+        };
+    }
+
+    private void loadData() {
+        Path file = FileUtil.getWebDir().resolve("mtr/data");
+        if (!Files.exists(file)) {
+            Path worldDir = getWorld().getRegionDirectory().getParent();
+            file = worldDir.resolve("mtr/data");
+        }
+        if (!Files.exists(file)) {
+            return;
+        }
+
+        try (Reader reader = Files.newBufferedReader(file)) {
+            JsonArray array = JsonParser.parseReader(reader).getAsJsonArray();
+            if (array.size() <= dimension()) {
+                return;
+            }
+            JsonObject obj = array.get(dimension()).getAsJsonObject();
+            JsonObject pos = obj.getAsJsonObject("positions");
+            if (pos != null) {
+                pos.entrySet().forEach(e -> positions.put(e.getKey(), e.getValue().getAsJsonObject()));
+            }
+            JsonObject sta = obj.getAsJsonObject("stations");
+            if (sta != null) {
+                sta.entrySet().forEach(e -> stations.put(e.getKey(), e.getValue().getAsJsonObject()));
+            }
+            JsonObject dep = obj.getAsJsonObject("depots");
+            if (dep != null) {
+                dep.entrySet().forEach(e -> depots.put(e.getKey(), e.getValue().getAsJsonObject()));
+            }
+            JsonArray routesArr = obj.getAsJsonArray("routes");
+            if (routesArr != null) {
+                routesArr.forEach(el -> routes.add(el.getAsJsonObject()));
+            }
+        } catch (IOException e) {
+            Logger.warn("Failed to read MTR data", e);
+        } catch (Exception e) {
+            Logger.warn("Failed to parse MTR data", e);
+        }
+    }
+
+    @Override
+    public @NotNull Collection<@NotNull Marker<?>> getMarkers() {
+        if (positions.isEmpty() && stations.isEmpty() && depots.isEmpty() && routes.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Marker<?>> markers = new ArrayList<>();
+
+        // station markers
+        stations.forEach((id, obj) -> {
+            int x = obj.get("x").getAsInt();
+            int z = obj.get("z").getAsInt();
+            String name = obj.has("name") ? obj.get("name").getAsString() : "";
+            Icon icon = Marker.icon("station_" + id, Point.of(x, z), this.stationIcon, 16);
+            if (!name.isBlank()) {
+                icon.setOptions(Options.builder()
+                        .tooltipContent(name)
+                        .tooltipDirection(Tooltip.Direction.TOP)
+                        .build());
+            }
+            markers.add(icon);
+        });
+
+        // depot markers
+        depots.forEach((id, obj) -> {
+            int x = obj.get("x").getAsInt();
+            int z = obj.get("z").getAsInt();
+            String name = obj.has("name") ? obj.get("name").getAsString() : "";
+            Icon icon = Marker.icon("depot_" + id, Point.of(x, z), this.depotIcon, 16);
+            if (!name.isBlank()) {
+                icon.setOptions(Options.builder()
+                        .tooltipContent(name)
+                        .tooltipDirection(Tooltip.Direction.TOP)
+                        .build());
+            }
+            markers.add(icon);
+        });
+
+        // route lines
+        for (JsonObject route : routes) {
+            JsonArray st = route.getAsJsonArray("stations");
+            if (st == null || st.size() < 2) {
+                continue;
+            }
+            String name = route.has("name") ? route.get("name").getAsString() : "route";
+            int color = route.has("color") ? route.get("color").getAsInt() : 0xFFFFFF;
+            Integer override = MTRLayerConfig.ROUTE_COLORS.get(name);
+            if (override != null) {
+                color = override;
+            }
+            Polyline line = Marker.polyline("route_" + name);
+            for (JsonElement el : st) {
+                String sid = el.getAsString();
+                JsonObject pos = positions.get(sid);
+                if (pos != null) {
+                    line.addPoint(Point.of(pos.get("x").getAsInt(), pos.get("y").getAsInt()));
+                } else {
+                    int split = sid.indexOf('_');
+                    if (split > 0) {
+                        sid = sid.substring(0, split);
+                    }
+                    JsonObject station = stations.get(sid);
+                    if (station != null) {
+                        line.addPoint(Point.of(station.get("x").getAsInt(), station.get("z").getAsInt()));
+                    }
+                }
+            }
+            line.setOptions(Options.builder()
+                    .stroke(new Stroke(2, color))
+                    .build());
+            markers.add(line);
+        }
+
+        return markers;
+    }
+}
+

--- a/core/src/main/java/net/pl3x/map/core/world/World.java
+++ b/core/src/main/java/net/pl3x/map/core/world/World.java
@@ -46,6 +46,7 @@ import net.pl3x.map.core.configuration.PlayersLayerConfig;
 import net.pl3x.map.core.configuration.SpawnLayerConfig;
 import net.pl3x.map.core.configuration.WorldBorderLayerConfig;
 import net.pl3x.map.core.configuration.WorldConfig;
+import net.pl3x.map.core.configuration.MTRLayerConfig;
 import net.pl3x.map.core.httpd.LiveDataHandler;
 import net.pl3x.map.core.image.IconImage;
 import net.pl3x.map.core.log.Logger;
@@ -56,6 +57,7 @@ import net.pl3x.map.core.markers.layer.Layer;
 import net.pl3x.map.core.markers.layer.PlayersLayer;
 import net.pl3x.map.core.markers.layer.SpawnLayer;
 import net.pl3x.map.core.markers.layer.WorldBorderLayer;
+import net.pl3x.map.core.markers.layer.MTRLayer;
 import net.pl3x.map.core.player.Player;
 import net.pl3x.map.core.registry.BiomeRegistry;
 import net.pl3x.map.core.registry.Registry;
@@ -165,6 +167,11 @@ public abstract class World extends Keyed {
         if (SpawnLayerConfig.ENABLED) {
             Logger.debug("Registering spawn layer");
             getLayerRegistry().register(SpawnLayer.KEY, new SpawnLayer(this));
+        }
+
+        if (MTRLayerConfig.ENABLED && MTRLayer.hasData(this)) {
+            Logger.debug("Registering MTR layer");
+            getLayerRegistry().register(MTRLayer.KEY, new MTRLayer(this));
         }
 
         if (PlayersLayerConfig.ENABLED) {


### PR DESCRIPTION
## Summary
- implement `MTRLayerConfig` with YAML options for station and depot icons as well as route color overrides
- add new `MTRLayer` server layer to read data from `web/mtr/data` (or `<world>/mtr/data`) and create station, depot and route markers
- register the MTR layer when worlds load if data is present
- revert web client to previous state and remove unused MTR web layer
- remove shipped station and depot icons
- avoid crashes when no data is available

## Testing
- `npm install`
- `npm run build`
- `./gradlew build --no-daemon` *(fails: waiting for lock)*

------
https://chatgpt.com/codex/tasks/task_e_6878ee68fdf0832db6489fb21f318139